### PR TITLE
Add getters. Update readme. Delete unused file. Add try_new for Polygon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "polygonical"
 description = "2d polygon geometry and operations"
 keywords = ["2d", "geometry", "polygon"]
 license = "MIT"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = [
     "Emily Selwood",
@@ -14,4 +14,6 @@ repository = "https://github.com/emilyselwood/polygonical"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+eyre = "0.6.12"
 float-cmp = "0.9.0"
+getset = "0.1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "polygonical"
 description = "2d polygon geometry and operations"
 keywords = ["2d", "geometry", "polygon"]
 license = "MIT"
-version = "0.6.0"
+version = "0.5.0"
 edition = "2021"
 authors = [
     "Emily Selwood",
@@ -14,6 +14,5 @@ repository = "https://github.com/emilyselwood/polygonical"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-eyre = "0.6.12"
 float-cmp = "0.9.0"
 getset = "0.1.6"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Things this library won't do.
 * 3d Geometry
 * Output to things like svg (that is for another library)
 * Coordinate system transforms, epsg codes, pixel space to world space etc.
-* epsg codes, pixel space to world space etc.
 
 ## Design goals
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Things this library won't do.
 
 * 3d Geometry
 * Output to things like svg (that is for another library)
-* Coordinate system transforms (see [Sguaba](https://github.com/helsing-ai/sguaba))
+* Coordinate system transforms, epsg codes, pixel space to world space etc.
 * epsg codes, pixel space to world space etc.
 
 ## Design goals

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rotate a polygon:
     use polygonical::polygon::Polygon;
     use polygonical::point::Point;
 
-    let poly = Polygon::new(vec![
+    let poly = Polygon::new_unchecked(vec![
         Point::new(0.0, 1.0),
         Point::new(1.0, 1.0),
         Point::new(1.0, 0.0),
@@ -40,7 +40,7 @@ Create an approximation of a circle:
         .map(|a| Point::new(radius, 0.0).rotate((a as f64).to_radians()).translate(&center))
         .collect();
 
-    let circle = Polygon::new(points);
+    let circle = Polygon::new_unchecked(points);
      
     let approx_area = circle.area();
     let area = std::f64::consts::PI * radius * radius;
@@ -78,7 +78,8 @@ Things this library won't do.
 
 * 3d Geometry
 * Output to things like svg (that is for another library)
-* Coordinate system transforms, epsg codes, pixel space to world space etc.
+* Coordinate system transforms (see [Sguaba](https://github.com/helsing-ai/sguaba))
+* epsg codes, pixel space to world space etc.
 
 ## Design goals
 

--- a/src/boundingbox.rs
+++ b/src/boundingbox.rs
@@ -1,11 +1,14 @@
 use std::fmt;
 
+use getset::Getters;
+
 use crate::{point::Point, polygon::Polygon};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Getters)]
+#[getset(get = "pub")]
 pub struct BoundingBox {
-    pub a: Point,
-    pub b: Point,
+    a: Point,
+    b: Point,
 }
 
 impl BoundingBox {
@@ -36,7 +39,7 @@ impl BoundingBox {
             Point::new(self.b.x, self.b.y),
             Point::new(self.b.x, self.a.y),
         ];
-        Polygon::new(points)
+        Polygon::new_unchecked(points)
     }
 
     pub fn intersects(&self, other: &BoundingBox) -> bool {

--- a/src/boundingbox.rs
+++ b/src/boundingbox.rs
@@ -29,44 +29,44 @@ impl BoundingBox {
     }
 
     pub fn contains(&self, p: Point) -> bool {
-        self.a.x <= p.x && self.b.x >= p.x && self.a.y <= p.y && self.b.y >= p.y
+        self.a.x() <= p.x() && self.b.x() >= p.x() && self.a.y() <= p.y() && self.b.y() >= p.y()
     }
 
     pub fn to_polygon(&self) -> Polygon {
         let points = vec![
-            Point::new(self.a.x, self.a.y),
-            Point::new(self.a.x, self.b.y),
-            Point::new(self.b.x, self.b.y),
-            Point::new(self.b.x, self.a.y),
+            Point::new(self.a.x(), self.a.y()),
+            Point::new(self.a.x(), self.b.y()),
+            Point::new(self.b.x(), self.b.y()),
+            Point::new(self.b.x(), self.a.y()),
         ];
         Polygon::new_unchecked(points)
     }
 
     pub fn intersects(&self, other: &BoundingBox) -> bool {
-        other.contains(Point::new(self.a.x, self.a.y))
-            || other.contains(Point::new(self.b.x, self.a.y))
-            || other.contains(Point::new(self.a.x, self.b.y))
-            || other.contains(Point::new(self.b.x, self.b.y))
-            || self.contains(Point::new(other.a.x, other.a.y))
-            || self.contains(Point::new(other.b.x, other.a.y))
-            || self.contains(Point::new(other.a.x, other.b.y))
-            || self.contains(Point::new(other.b.x, other.b.y))
-            || (other.a.x >= self.a.x
-                && other.b.x <= self.b.x
-                && self.a.y >= other.a.y
-                && self.b.y <= other.b.y)
-            || (other.a.y >= self.a.y
-                && other.b.y <= self.b.y
-                && self.a.x >= other.a.x
-                && self.b.x <= other.b.x)
+        other.contains(Point::new(self.a.x(), self.a.y()))
+            || other.contains(Point::new(self.b.x(), self.a.y()))
+            || other.contains(Point::new(self.a.x(), self.b.y()))
+            || other.contains(Point::new(self.b.x(), self.b.y()))
+            || self.contains(Point::new(other.a.x(), other.a.y()))
+            || self.contains(Point::new(other.b.x(), other.a.y()))
+            || self.contains(Point::new(other.a.x(), other.b.y()))
+            || self.contains(Point::new(other.b.x(), other.b.y()))
+            || (other.a.x() >= self.a.x()
+                && other.b.x() <= self.b.x()
+                && self.a.y() >= other.a.y()
+                && self.b.y() <= other.b.y())
+            || (other.a.y() >= self.a.y()
+                && other.b.y() <= self.b.y()
+                && self.a.x() >= other.a.x()
+                && self.b.x() <= other.b.x())
     }
 
     pub fn width(&self) -> f64 {
-        self.b.x - self.a.x
+        self.b.x() - self.a.x()
     }
 
     pub fn height(&self) -> f64 {
-        self.b.y - self.a.y
+        self.b.y() - self.a.y()
     }
 }
 

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -3,26 +3,26 @@ use crate::point::Point;
 
 // calculate the area of a triangle
 pub fn area_of_triangle(a: Point, b: Point, c: Point) -> f64 {
-    0.5 * matrix_determinant(b.y - a.x, b.x - a.x, c.y - a.y, c.x - a.y)
+    0.5 * matrix_determinant(b.y() - a.x(), b.x() - a.x(), c.y() - a.y(), c.x() - a.x())
 }
 
 /// Find the point of intersection of two lines a->b and c->d
 /// Will return None if the lines don't intersect.
 pub fn point_of_intersection(a: Point, b: Point, c: Point, d: Point) -> Option<Point> {
-    let a1 = b.y - a.y;
-    let b1 = a.x - b.x;
-    let c1 = (a1 * a.x) + (b1 * a.y);
+    let a1 = b.y() - a.y();
+    let b1 = a.x() - b.x();
+    let c1 = (a1 * a.x()) + (b1 * a.y());
 
-    let a2 = d.y - c.y;
-    let b2 = c.x - d.x;
-    let c2 = (a2 * c.x) + (b2 * c.y);
+    let a2 = d.y() - c.y();
+    let b2 = c.x() - d.x();
+    let c2 = (a2 * c.x()) + (b2 * c.y());
 
     let determinant = a1 * b2 - a2 * b1;
 
     if determinant == 0.0 {
         // they might be parallel but overlap so check if the start of the second line is in side the first.
-        let x_r = (b.x - c.x) / (b.x - a.x);
-        let y_r = (b.y - c.y) / (b.y - a.y);
+        let x_r = (b.x() - c.x()) / (b.x() - a.x());
+        let y_r = (b.y() - c.y()) / (b.y() - a.y());
         if x_r > 0.0 && x_r < 1.0 && y_r > 0.0 && y_r < 1.0 {
             return Some(c);
         }
@@ -33,11 +33,11 @@ pub fn point_of_intersection(a: Point, b: Point, c: Point, d: Point) -> Option<P
     let y = (a1 * c2 - a2 * c1) / determinant;
 
     // check that x,y is inside the two points a->b and c->d
-    let x_r1 = (b.x - x) / (b.x - a.x);
-    let y_r1 = (b.y - y) / (b.y - a.y);
+    let x_r1 = (b.x() - x) / (b.x() - a.x());
+    let y_r1 = (b.y() - y) / (b.y() - a.y());
 
-    let x_r2 = (d.x - x) / (d.x - c.x);
-    let y_r2 = (d.y - y) / (d.y - c.y);
+    let x_r2 = (d.x() - x) / (d.x() - c.x());
+    let y_r2 = (d.y() - y) / (d.y() - c.y());
 
     // The clippy suggestion here is less obvious to me
     #[allow(clippy::manual_range_contains)]
@@ -103,7 +103,7 @@ enum Orientation {
 }
 
 fn orientation(a: Point, b: Point, c: Point) -> Orientation {
-    let v: f64 = (b.y - a.y) * (c.x - b.x) - (b.x - a.x) * (c.y - b.y);
+    let v: f64 = (b.y() - a.y()) * (c.x() - b.x()) - (b.x() - a.x()) * (c.y() - b.y());
 
     if v == 0.0 {
         return Orientation::Collinear;
@@ -114,7 +114,10 @@ fn orientation(a: Point, b: Point, c: Point) -> Orientation {
 }
 
 fn on_segment(a: Point, b: Point, c: Point) -> bool {
-    b.x <= a.x.max(c.x) && b.x >= a.x.min(c.x) && b.y <= a.y.max(c.y) && b.y >= a.y.min(c.y)
+    b.x() <= a.x().max(c.x())
+        && b.x() >= a.x().min(c.x())
+        && b.y() <= a.y().max(c.y())
+        && b.y() >= a.y().min(c.y())
 }
 
 fn matrix_determinant(a: f64, b: f64, c: f64, d: f64) -> f64 {

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -3,7 +3,7 @@ use crate::point::Point;
 
 // calculate the area of a triangle
 pub fn area_of_triangle(a: Point, b: Point, c: Point) -> f64 {
-    0.5 * matrix_determinant(b.y() - a.x(), b.x() - a.x(), c.y() - a.y(), c.x() - a.x())
+    0.5 * matrix_determinant(b.y() - a.x(), b.x() - a.x(), c.y() - a.y(), c.x() - a.y())
 }
 
 /// Find the point of intersection of two lines a->b and c->d

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ pub mod point;
 pub mod polygon;
 
 mod geom;
-mod maths;
 
 #[cfg(test)]
 mod tests {

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,11 +1,15 @@
 use std::fmt;
 
+use getset::Getters;
+
 use crate::{geom, point::Point};
 
 /// Represents a line between two points.
+#[derive(Debug, Clone, Getters)]
+#[getset(get = "pub")]
 pub struct Line {
-    pub a: Point,
-    pub b: Point,
+    a: Point,
+    b: Point,
 }
 
 impl Line {

--- a/src/maths.rs
+++ b/src/maths.rs
@@ -1,3 +1,0 @@
-/*
-Maths helper functions. None of this is exposed outside the library
-*/

--- a/src/point.rs
+++ b/src/point.rs
@@ -3,10 +3,11 @@ use std::fmt;
 
 use float_cmp::approx_eq;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, getset::CopyGetters)]
+#[getset(get_copy = "pub")]
 pub struct Point {
-    pub x: f64,
-    pub y: f64,
+    x: f64,
+    y: f64,
 }
 
 impl Point {
@@ -46,32 +47,32 @@ impl Point {
     /// Given another point return the min of the x and y values
     pub fn min(&self, other: &Point) -> Point {
         Point {
-            x: self.x.min(other.x),
-            y: self.y.min(other.y),
+            x: self.x().min(other.x()),
+            y: self.y().min(other.y()),
         }
     }
 
     /// Given another point return the max of the x and y values
     pub fn max(&self, other: &Point) -> Point {
         Point {
-            x: self.x.max(other.x),
-            y: self.y.max(other.y),
+            x: self.x().max(other.x()),
+            y: self.y().max(other.y()),
         }
     }
 
     /// Flip the sign of both x and y coords
     pub fn invert(&self) -> Point {
         Point {
-            x: -self.x,
-            y: -self.y,
+            x: -self.x(),
+            y: -self.y(),
         }
     }
 
     /// offset / translate this point by another one.
     pub fn translate(&self, by: &Point) -> Point {
         Point {
-            x: self.x + by.x,
-            y: self.y + by.y,
+            x: self.x() + by.x(),
+            y: self.y() + by.y(),
         }
     }
 
@@ -79,7 +80,7 @@ impl Point {
     pub fn angle_to(&self, other: &Point) -> f64 {
         let translated = other.translate(&self.invert());
 
-        let result = translated.y.atan2(translated.x);
+        let result = translated.y().atan2(translated.x());
         if result < 0.0 {
             return result + 360.0_f64.to_radians();
         }
@@ -89,23 +90,23 @@ impl Point {
     /// Rotate the given point around the origin by angle radians.
     pub fn rotate(&self, angle: f64) -> Point {
         Point {
-            x: (self.x * angle.cos()) - (self.y * angle.sin()),
-            y: (self.y * angle.cos()) + (self.x * angle.sin()),
+            x: (self.x() * angle.cos()) - (self.y() * angle.sin()),
+            y: (self.y() * angle.cos()) + (self.x() * angle.sin()),
         }
     }
 }
 
 impl fmt::Display for Point {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(formatter, "({}, {})", self.x, self.y)
+        write!(formatter, "({}, {})", self.x(), self.y())
     }
 }
 
 impl PartialEq for Point {
     // float equal is always evil, but we will use approx_eq here to give us a reasonable answer.
     fn eq(&self, other: &Self) -> bool {
-        approx_eq!(f64, self.x, other.x, epsilon = 0.000003, ulps = 2)
-            && approx_eq!(f64, self.y, other.y, epsilon = 0.000003, ulps = 2)
+        approx_eq!(f64, self.x(), other.x(), epsilon = 0.000003, ulps = 2)
+            && approx_eq!(f64, self.y(), other.y(), epsilon = 0.000003, ulps = 2)
     }
 }
 
@@ -145,8 +146,8 @@ mod tests {
     #[test]
     fn from_int() {
         let p = Point::new(1, 5);
-        assert_eq!(p.x, 1.0);
-        assert_eq!(p.y, 5.0);
+        assert_eq!(p.x(), 1.0);
+        assert_eq!(p.y(), 5.0);
     }
 
     macro_rules! angle_tests {

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -40,7 +40,7 @@ pub struct Polygon {
 }
 
 impl Polygon {
-    /// Create a new polygon
+    /// Create a new polygon.
     ///
     /// The vector of points must contain at least 3 elements or this will panic.
     pub fn new_unchecked(points: Vec<Point>) -> Self {

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -37,7 +37,7 @@ impl Polygon {
 
     /// Create a new polygon.
     ///
-    /// The vector of points must contain at least 3 elements or this will panic.
+    /// Will return an Err if points does not contain at least 3 elements
     pub fn try_new(points: Vec<Point>) -> Result<Self> {
         ensure!(
             points.len() >= 3,

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -1,5 +1,4 @@
 use float_cmp::approx_eq;
-use getset::Getters;
 
 use crate::{boundingbox::BoundingBox, geom, point::Point};
 use std::{
@@ -32,7 +31,7 @@ impl Error for PolygonError {}
 
 /// Polygon describes the points around the edge of a shape. It can only contain a single path, no holes
 #[allow(clippy::len_without_is_empty)] // a polygon can never be empty so an is_empty function would always return false.
-#[derive(Debug, Clone, Getters)]
+#[derive(Debug, Clone, getset::Getters)]
 #[getset(get = "pub")]
 pub struct Polygon {
     points: Vec<Point>,
@@ -151,8 +150,8 @@ impl Polygon {
         let mut y = 0.0;
 
         for p in self.points.iter() {
-            x += p.x;
-            y += p.y;
+            x += p.x();
+            y += p.y();
         }
         let len = self.len() as f64;
 


### PR DESCRIPTION
Small drive-by MR for your consideration. Thank you for the library - used recently on Advent of Code!

This MR:
- introduces `Getters` to allow removal of `pub` from the fields on `Polygon`, `Line` and `Point` and then have auto derivation of getters for those fields as there was a (small) risk of a user overwriting the bounding box after instantiation [BREAKING CHANGE]
- renames `new()` on `Polygon` to `new_unchecked()` to indicate users should check the vec of points has 3 or more entries [BREAKING CHANGE]
- adds try_new to `Polygon` if users want to use `Result` vs checking themselves if there are enough points
- few small typo corrections
- removes maths.rs that was unused

If you'd like me to split this up into smaller MRs, I'd be happy to do that